### PR TITLE
DecodingChart Legends

### DIFF
--- a/VoxPop/Site/Content/VoxPopCharts.js
+++ b/VoxPop/Site/Content/VoxPopCharts.js
@@ -23,6 +23,8 @@ function GenerateChart(identifier, data) {
     noVotes = true;
 
     for (var i = 0; i < data.length; i++) {
+        data[i].label = DecodeHtml(data[i].label);
+
         if (data[i].value !== 0) {
             noVotes = false;
         }
@@ -42,4 +44,8 @@ function GenerateChart(identifier, data) {
         //segmentStrokeWidth : 4
 
     });
+}
+
+function DecodeHtml(inputString) {
+    return $("<div/>").html(inputString).text();
 }


### PR DESCRIPTION
Chart legends now showing special characters normally.
I'm not 100% sure on the cause, but it seems that after passing the poll option names to the javascript, the string were being encoded.
I have added a function to the `VoxPopCharts.js` file which will decode them again before displaying.

![unescapedchartlabel](https://cloud.githubusercontent.com/assets/4104871/6546967/1e945914-c5c0-11e4-999f-73343a3921cf.png)

closes #60
