### PR TITLE
changed default meta image from pipe-head (pretty cool actually) to our ...

### DIFF
--- a/VoxPop/Site/Views/Shared/_DefaultMetaTags.cshtml
+++ b/VoxPop/Site/Views/Shared/_DefaultMetaTags.cshtml
@@ -1,4 +1,4 @@
 ﻿<meta property="og:title" content="Got questions? Get Answers." />
 <meta property="og:description" content="With VOXPOP you can write stories on issues that are important to you and get feedback from readers." />
-<meta property="og:image" content="http://www-static.weddingbee.com/pics/36694/head.jpeg" />
+<meta property="og:image" content="https://cloud.githubusercontent.com/assets/8128937/6772456/8e0d0b9c-d0f6-11e4-9db2-14062e64a36a.png" />
 <meta property="og:url" content="@Request.Url" />


### PR DESCRIPTION
...VP 'O'

This 
![image](https://cloud.githubusercontent.com/assets/8128937/6782903/c2af1462-d16e-11e4-943e-39b187d1a648.png)

to this
![image](https://cloud.githubusercontent.com/assets/8128937/6782894/b678d174-d16e-11e4-9e8b-2536891b13d9.png)
