### PR TITLE
(psuedo) fixes #92

### DIFF
--- a/VoxPop/Site/Views/Stories/Index.cshtml
+++ b/VoxPop/Site/Views/Stories/Index.cshtml
@@ -30,7 +30,7 @@
 
         foreach (KeyValuePair<string, int> pollItem in blogPost.Poll)
         {
-            string option = @pollItem.Key.Replace("+", " ");
+            string option = @pollItem.Key.Replace("+", " ").Replace("%2c", ",").Replace("%27", "'").Replace("%3f", "?");
             <script>
                 chartData.push(VoxPopCharts.GetPollData("@option", @pollItem.Value));
             </script>


### PR DESCRIPTION
(psuedo) fix for #92 using .Replace(), will keep cropping up as people use different punctuation in their options but should be relatively stable as the encoded versions of the replaced characters are pretty obscure.
